### PR TITLE
bump versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "lodash": "~4.13.1",
     "q": "~1.4.1",
     "requestretry": "~1.9.0",
-    "sauce-tunnel": "~2.5.0",
-    "saucelabs": "~1.2.0"
+    "sauce-tunnel": "^2.5.0",
+    "saucelabs": "^1.5.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.1"


### PR DESCRIPTION
avoid https://www.npmjs.com/advisories/593 in dependency chain.